### PR TITLE
Add <relativePath> to <parent> elements

### DIFF
--- a/detection/audio-video-utils/pom.xml
+++ b/detection/audio-video-utils/pom.xml
@@ -34,6 +34,7 @@
         <artifactId>openmpf-java-component-sdk</artifactId>
         <groupId>org.mitre.mpf</groupId>
         <version>0.9.0</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <name>OpenMPF Audio-Video Utils</name>

--- a/detection/java-component-api/pom.xml
+++ b/detection/java-component-api/pom.xml
@@ -34,6 +34,7 @@
         <artifactId>openmpf-java-component-sdk</artifactId>
         <groupId>org.mitre.mpf</groupId>
         <version>0.9.0</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>mpf-java-component-api</artifactId>


### PR DESCRIPTION
This addresses an issue I found when helping Erik get his dev environment set up. If you leave out the relativePath element Maven will only look one directory up for the parent pom.xml. If there isn't a pom.xml exactly one directory above the current directory Maven will look for it in a Maven repo. This issue was introduced when the child projects were moved in to the detection directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-java-component-sdk/3)
<!-- Reviewable:end -->
