### PR TITLE
added feed forward tracks to messaging

### DIFF
--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFAudioJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFAudioJob.java
@@ -27,6 +27,7 @@
 package org.mitre.mpf.component.api;
 
 import java.util.Map;
+import org.mitre.mpf.component.api.detection.MPFAudioTrack;
 
 /**
  * A job description for an audio job.  The component will act on a single audio file, with a start and stop time to
@@ -36,9 +37,31 @@ public class MPFAudioJob extends MPFJob {
 
     private final int startTime;
     private final int stopTime;
+    private final boolean hasFeedForwardTrack;
+    private MPFAudioTrack feedForwardTrack;
 
     /**
-     * Create a new job object for an audio job.
+     *  An AudioJob may contain a feed-forward track from a previous stage
+     *  in the job pipeline.
+     *
+     * @return true if the job contains a valid feed-forward track; otherwise, false.
+     */
+    public boolean hasFeedForwardTrack() {
+	return hasFeedForwardTrack;
+    }
+
+    /**
+     *  An AudioJob may contain a feed-forward track from a previous stage
+     *  in the job pipeline.
+     *
+     * @return the feed-forward track.
+     */
+    public MPFAudioTrack getFeedForwardTrack() {
+	return feedForwardTrack;
+    }
+
+    /**
+     * Create a new job object for an audio job that does not have a feed-forward track.
      *
      * @param jobName   The name of the job being run.  Useful for logging purposes
      * @param dataUri   The URI for the piece of media being processed.
@@ -55,6 +78,36 @@ public class MPFAudioJob extends MPFJob {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startTime=startTime;
         this.stopTime=stopTime;
+	this.hasFeedForwardTrack=false;
+    }
+
+    /**
+     * Create a new job object for an audio job that has a feed-forward track.
+     *
+     * @param jobName   The name of the job being run.  Useful for logging purposes
+     * @param dataUri   The URI for the piece of media being processed.
+     * @param jobProperties  Values for any properties the component requires.
+     * @param mediaProperties   Properties about the media being processed.  Audio files have a "DURATION" property,
+     *                          represented in milliseconds.
+     * @param startTime The beginning of the relevant range within the file. Nothing before the start time will be
+     *                  detected.
+     * @param stopTime  The end of the relevant range within the file. Nothing after the stop time  will be detected.
+     *                    stopFrame will not be processed by the component.
+     * @param track       An instance of an MPFAudioTrack.
+     */
+
+    public MPFAudioJob(String jobName,
+		       String dataUri,
+		       final Map<String, String> jobProperties,
+                       final Map <String, String> mediaProperties,
+		       int startTime,
+		       int stopTime,
+		       MPFAudioTrack track) {
+        super(jobName, dataUri, jobProperties, mediaProperties);
+        this.startTime=startTime;
+        this.stopTime=stopTime;
+	this.hasFeedForwardTrack=true;
+	this.feedForwardTrack=track;
     }
 
     /**

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFAudioJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFAudioJob.java
@@ -41,23 +41,23 @@ public class MPFAudioJob extends MPFJob {
     private MPFAudioTrack feedForwardTrack;
 
     /**
-     *  An AudioJob may contain a feed-forward track from a previous stage
+     *  An audio job may contain a feed-forward track from a previous stage
      *  in the job pipeline.
      *
      * @return true if the job contains a valid feed-forward track; otherwise, false.
      */
     public boolean hasFeedForwardTrack() {
-	return hasFeedForwardTrack;
+        return hasFeedForwardTrack;
     }
 
     /**
-     *  An AudioJob may contain a feed-forward track from a previous stage
+     *  An audio job may contain a feed-forward track from a previous stage
      *  in the job pipeline.
      *
      * @return the feed-forward track.
      */
     public MPFAudioTrack getFeedForwardTrack() {
-	return feedForwardTrack;
+        return feedForwardTrack;
     }
 
     /**
@@ -78,7 +78,7 @@ public class MPFAudioJob extends MPFJob {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startTime=startTime;
         this.stopTime=stopTime;
-	this.hasFeedForwardTrack=false;
+        this.hasFeedForwardTrack=false;
     }
 
     /**
@@ -97,17 +97,17 @@ public class MPFAudioJob extends MPFJob {
      */
 
     public MPFAudioJob(String jobName,
-		       String dataUri,
-		       final Map<String, String> jobProperties,
+                       String dataUri,
+                       final Map<String, String> jobProperties,
                        final Map <String, String> mediaProperties,
-		       int startTime,
-		       int stopTime,
-		       MPFAudioTrack track) {
+                       int startTime,
+                       int stopTime,
+                       MPFAudioTrack track) {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startTime=startTime;
         this.stopTime=stopTime;
-	this.hasFeedForwardTrack=true;
-	this.feedForwardTrack=track;
+        this.hasFeedForwardTrack=true;
+        this.feedForwardTrack=track;
     }
 
     /**

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFAudioJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFAudioJob.java
@@ -37,18 +37,7 @@ public class MPFAudioJob extends MPFJob {
 
     private final int startTime;
     private final int stopTime;
-    private final boolean hasFeedForwardTrack;
     private MPFAudioTrack feedForwardTrack;
-
-    /**
-     *  An audio job may contain a feed-forward track from a previous stage
-     *  in the job pipeline.
-     *
-     * @return true if the job contains a valid feed-forward track; otherwise, false.
-     */
-    public boolean hasFeedForwardTrack() {
-        return hasFeedForwardTrack;
-    }
 
     /**
      *  An audio job may contain a feed-forward track from a previous stage
@@ -57,7 +46,7 @@ public class MPFAudioJob extends MPFJob {
      * @return the feed-forward track.
      */
     public MPFAudioTrack getFeedForwardTrack() {
-        return feedForwardTrack;
+        return feedForwardTrack;   // Could be null; be sure to check
     }
 
     /**
@@ -78,7 +67,7 @@ public class MPFAudioJob extends MPFJob {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startTime=startTime;
         this.stopTime=stopTime;
-        this.hasFeedForwardTrack=false;
+        this.feedForwardTrack = null;
     }
 
     /**
@@ -106,7 +95,6 @@ public class MPFAudioJob extends MPFJob {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startTime=startTime;
         this.stopTime=stopTime;
-        this.hasFeedForwardTrack=true;
         this.feedForwardTrack=track;
     }
 

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFImageJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFImageJob.java
@@ -33,18 +33,7 @@ import org.mitre.mpf.component.api.detection.MPFImageLocation;
  * A job description for an image job.  The component will act on a single image medium.
  */
 public class MPFImageJob extends MPFJob {
-    private final boolean hasFeedForwardLocation;
     private MPFImageLocation feedForwardLocation;
-
-    /**
-     *  An image job may contain a feed-forward location from a previous stage
-     *  in the job pipeline.
-     *
-     * @return true if the job contains a valid feed-forward location; otherwise, false.
-     */
-    public boolean hasFeedForwardLocation() {
-	return hasFeedForwardLocation;
-    }
 
     /**
      *  An image job may contain a feed-forward location from a previous stage
@@ -53,7 +42,7 @@ public class MPFImageJob extends MPFJob {
      * @return the feed-forward location
      */
     public MPFImageLocation getFeedForwardLocation() {
-	return feedForwardLocation;
+        return feedForwardLocation;   // Could be null; be sure to check
     }
 
     /**
@@ -69,7 +58,7 @@ public class MPFImageJob extends MPFJob {
     public MPFImageJob(String jobName, String dataUri, final Map<String, String> jobProperties,
                       final Map <String, String> mediaProperties) {
         super(jobName, dataUri, jobProperties, mediaProperties);
-	this.hasFeedForwardLocation=false;
+        this.feedForwardLocation=null;
     }
 
     /**
@@ -83,12 +72,11 @@ public class MPFImageJob extends MPFJob {
      *                          does not have EXIF metadata, no properties will be set.
      */
     public MPFImageJob(String jobName,
-		       String dataUri,
-		       final Map<String, String> jobProperties,
-		       final Map <String, String> mediaProperties,
-		       MPFImageLocation location) {
+                       String dataUri,
+                       final Map<String, String> jobProperties,
+                       final Map <String, String> mediaProperties,
+                       MPFImageLocation location) {
         super(jobName, dataUri, jobProperties, mediaProperties);
-	this.hasFeedForwardLocation=true;
-	this.feedForwardLocation=location;
+        this.feedForwardLocation=location;
     }
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFImageJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFImageJob.java
@@ -37,7 +37,7 @@ public class MPFImageJob extends MPFJob {
     private MPFImageLocation feedForwardLocation;
 
     /**
-     *  An ImageJob may contain a feed-forward location from a previous stage
+     *  An image job may contain a feed-forward location from a previous stage
      *  in the job pipeline.
      *
      * @return true if the job contains a valid feed-forward location; otherwise, false.
@@ -47,7 +47,7 @@ public class MPFImageJob extends MPFJob {
     }
 
     /**
-     *  An ImageJob may contain a feed-forward location from a previous stage
+     *  An image job may contain a feed-forward location from a previous stage
      *  in the job pipeline.
      *
      * @return the feed-forward location

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFImageJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFImageJob.java
@@ -27,14 +27,37 @@
 package org.mitre.mpf.component.api;
 
 import java.util.Map;
+import org.mitre.mpf.component.api.detection.MPFImageLocation;
 
 /**
  * A job description for an image job.  The component will act on a single image medium.
  */
 public class MPFImageJob extends MPFJob {
+    private final boolean hasFeedForwardLocation;
+    private MPFImageLocation feedForwardLocation;
 
     /**
-     * Create a new job object for an image job.
+     *  An ImageJob may contain a feed-forward location from a previous stage
+     *  in the job pipeline.
+     *
+     * @return true if the job contains a valid feed-forward location; otherwise, false.
+     */
+    public boolean hasFeedForwardLocation() {
+	return hasFeedForwardLocation;
+    }
+
+    /**
+     *  An ImageJob may contain a feed-forward location from a previous stage
+     *  in the job pipeline.
+     *
+     * @return the feed-forward location
+     */
+    public MPFImageLocation getFeedForwardLocation() {
+	return feedForwardLocation;
+    }
+
+    /**
+     * Create a new job object for an image job that does not have a feed-forward location.
      *
      * @param jobName    The name of the job being run.  Useful for logging purposes
      * @param dataUri    The URI for the piece of media being processed.
@@ -46,5 +69,26 @@ public class MPFImageJob extends MPFJob {
     public MPFImageJob(String jobName, String dataUri, final Map<String, String> jobProperties,
                       final Map <String, String> mediaProperties) {
         super(jobName, dataUri, jobProperties, mediaProperties);
+	this.hasFeedForwardLocation=false;
+    }
+
+    /**
+     * Create a new job object for an image job that has a feed-forward location.
+     *
+     * @param jobName    The name of the job being run.  Useful for logging purposes
+     * @param dataUri    The URI for the piece of media being processed.
+     * @param jobProperties  Values for any properties the component requires.
+     * @param mediaProperties   Properties about the media being processed.  Image files with EXIF metadata will
+     *                          have "ROTATION", "HORIZONTAL_FLIP", and "EXIF_ORIENTATION" flags.  If the image source
+     *                          does not have EXIF metadata, no properties will be set.
+     */
+    public MPFImageJob(String jobName,
+		       String dataUri,
+		       final Map<String, String> jobProperties,
+		       final Map <String, String> mediaProperties,
+		       MPFImageLocation location) {
+        super(jobName, dataUri, jobProperties, mediaProperties);
+	this.hasFeedForwardLocation=true;
+	this.feedForwardLocation=location;
     }
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFVideoJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFVideoJob.java
@@ -37,7 +37,6 @@ public class MPFVideoJob extends MPFJob {
 
     private final int startFrame;
     private final int stopFrame;
-    private final boolean hasFeedForwardTrack;
     private MPFVideoTrack feedForwardTrack;
 
     /**
@@ -64,20 +63,10 @@ public class MPFVideoJob extends MPFJob {
      *  A video job may contain a feed-forward track from a previous stage
      *  in the job pipeline.
      *
-     * @return true if the job contains a valid feed-forward track; otherwise, false.
-     */
-    public boolean hasFeedForwardTrack() {
-        return hasFeedForwardTrack;
-    }
-
-    /**
-     *  A video job may contain a feed-forward track from a previous stage
-     *  in the job pipeline.
-     *
      * @return the feed-forward track
      */
     public MPFVideoTrack getFeedForwardTrack() {
-        return feedForwardTrack;
+        return feedForwardTrack;   // Could be null; be sure to check
     }
 
     /**
@@ -98,7 +87,7 @@ public class MPFVideoJob extends MPFJob {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startFrame=startFrame;
         this.stopFrame=stopFrame;
-        this.hasFeedForwardTrack=false;
+        this.feedForwardTrack=null;
     }
 
     /**
@@ -125,7 +114,6 @@ public class MPFVideoJob extends MPFJob {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startFrame=startFrame;
         this.stopFrame=stopFrame;
-        this.hasFeedForwardTrack=true;
         this.feedForwardTrack=track;
     }
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFVideoJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFVideoJob.java
@@ -27,6 +27,7 @@
 package org.mitre.mpf.component.api;
 
 import java.util.Map;
+import org.mitre.mpf.component.api.detection.MPFVideoTrack;
 
 /**
  * A job description for a video job.  The component will act on a single video file, with a start and stop frame to
@@ -36,6 +37,8 @@ public class MPFVideoJob extends MPFJob {
 
     private final int startFrame;
     private final int stopFrame;
+    private final boolean hasFeedForwardTrack;
+    private MPFVideoTrack feedForwardTrack;
 
     /**
      *  The first frame of the relevant range within the video. Frames before the startFrame will not be processed
@@ -58,7 +61,27 @@ public class MPFVideoJob extends MPFJob {
     }
 
     /**
-     * Create a new job object for a video job.
+     *  A VideoJob may contain a feed-forward track from a previous stage
+     *  in the job pipeline.
+     *
+     * @return true if the job contains a valid feed-forward track; otherwise, false.
+     */
+    public boolean hasFeedForwardTrack() {
+	return hasFeedForwardTrack;
+    }
+
+    /**
+     *  A VideoJob may contain a feed-forward track from a previous stage
+     *  in the job pipeline.
+     *
+     * @return the feed-forward track
+     */
+    public MPFVideoTrack getFeedForwardTrack() {
+	return feedForwardTrack;
+    }
+
+    /**
+     * Create a new job object for a video job that has no feed-forward track.
      *
      * @param jobName     The name of the job being run.  Useful for logging purposes
      * @param dataUri     The URI for the piece of media being processed.
@@ -75,5 +98,34 @@ public class MPFVideoJob extends MPFJob {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startFrame=startFrame;
         this.stopFrame=stopFrame;
+	this.hasFeedForwardTrack=false;
+    }
+
+    /**
+     * Create a new job object for a video job that has a feed-forward track.
+     *
+     * @param jobName     The name of the job being run.  Useful for logging purposes
+     * @param dataUri     The URI for the piece of media being processed.
+     * @param jobProperties  Values for any properties the component requires.
+     * @param mediaProperties   Properties about the media being processed.  Video files have
+     *                    "DURATION" and "FPS" (frames per second) properties.
+     * @param startFrame  The first frame of the relevant range within the video. Frames before
+     *                    the startFrame will not be processed by the component.
+     * @param stopFrame   The last frame of the relevant range within the video. Frames after the
+     *                    stopFrame will not be processed by the component.
+     * @param track       An instance of an MPFVideoTrack.
+     */
+    public MPFVideoJob(String jobName,
+		       String dataUri,
+		       final Map<String, String> jobProperties,
+                       final Map <String, String> mediaProperties,
+		       int startFrame,
+		       int stopFrame,
+		       MPFVideoTrack track) {
+        super(jobName, dataUri, jobProperties, mediaProperties);
+        this.startFrame=startFrame;
+        this.stopFrame=stopFrame;
+	this.hasFeedForwardTrack=true;
+	this.feedForwardTrack=track;
     }
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFVideoJob.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/MPFVideoJob.java
@@ -61,23 +61,23 @@ public class MPFVideoJob extends MPFJob {
     }
 
     /**
-     *  A VideoJob may contain a feed-forward track from a previous stage
+     *  A video job may contain a feed-forward track from a previous stage
      *  in the job pipeline.
      *
      * @return true if the job contains a valid feed-forward track; otherwise, false.
      */
     public boolean hasFeedForwardTrack() {
-	return hasFeedForwardTrack;
+        return hasFeedForwardTrack;
     }
 
     /**
-     *  A VideoJob may contain a feed-forward track from a previous stage
+     *  A video job may contain a feed-forward track from a previous stage
      *  in the job pipeline.
      *
      * @return the feed-forward track
      */
     public MPFVideoTrack getFeedForwardTrack() {
-	return feedForwardTrack;
+        return feedForwardTrack;
     }
 
     /**
@@ -98,7 +98,7 @@ public class MPFVideoJob extends MPFJob {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startFrame=startFrame;
         this.stopFrame=stopFrame;
-	this.hasFeedForwardTrack=false;
+        this.hasFeedForwardTrack=false;
     }
 
     /**
@@ -116,16 +116,16 @@ public class MPFVideoJob extends MPFJob {
      * @param track       An instance of an MPFVideoTrack.
      */
     public MPFVideoJob(String jobName,
-		       String dataUri,
-		       final Map<String, String> jobProperties,
+                       String dataUri,
+                       final Map<String, String> jobProperties,
                        final Map <String, String> mediaProperties,
-		       int startFrame,
-		       int stopFrame,
-		       MPFVideoTrack track) {
+                       int startFrame,
+                       int stopFrame,
+                       MPFVideoTrack track) {
         super(jobName, dataUri, jobProperties, mediaProperties);
         this.startFrame=startFrame;
         this.stopFrame=stopFrame;
-	this.hasFeedForwardTrack=true;
-	this.feedForwardTrack=track;
+        this.hasFeedForwardTrack=true;
+        this.feedForwardTrack=track;
     }
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionAudioRequest.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionAudioRequest.java
@@ -31,7 +31,6 @@ public class MPFDetectionAudioRequest {
 
     private int startTime;
     private int stopTime;
-    private final boolean hasFeedForwardTrack;
     private MPFAudioTrack feedForwardTrack;
 
     public int getStartTime() {
@@ -50,30 +49,25 @@ public class MPFDetectionAudioRequest {
         this.stopTime = stopTime;
     }
 
-    public boolean hasFeedForwardTrack() {
-	return hasFeedForwardTrack;
-    }
-
     public MPFAudioTrack getFeedForwardTrack() {
-	return feedForwardTrack;
+        return feedForwardTrack;   // Could be null; be sure to check
     }
 
     // Constructor for a request that does not have a feed-forward track
     public MPFDetectionAudioRequest(int startTime,
-				    int stopTime) {
+                                    int stopTime) {
         this.startTime = startTime;
         this.stopTime = stopTime;
-	this.hasFeedForwardTrack = false;
+        this.feedForwardTrack = null;
     }
 
     // Constructor for a request that has a feed-forward track
     public MPFDetectionAudioRequest(int startTime,
-				    int stopTime,
-				    MPFAudioTrack track) {
+                                    int stopTime,
+                                    MPFAudioTrack track) {
         this.startTime = startTime;
         this.stopTime = stopTime;
-	this.hasFeedForwardTrack = true;
-	this.feedForwardTrack = track;
+        this.feedForwardTrack = track;
     }
 
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionAudioRequest.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionAudioRequest.java
@@ -25,11 +25,14 @@
  ******************************************************************************/
 
 package org.mitre.mpf.component.api.messaging.detection;
+import org.mitre.mpf.component.api.detection.MPFAudioTrack;
 
 public class MPFDetectionAudioRequest {
 
     private int startTime;
     private int stopTime;
+    private final boolean hasFeedForwardTrack;
+    private MPFAudioTrack feedForwardTrack;
 
     public int getStartTime() {
         return startTime;
@@ -47,12 +50,30 @@ public class MPFDetectionAudioRequest {
         this.stopTime = stopTime;
     }
 
-	public MPFDetectionAudioRequest(
-        int startTime,
-        int stopTime
-    ) {
+    public boolean hasFeedForwardTrack() {
+	return hasFeedForwardTrack;
+    }
+
+    public MPFAudioTrack getFeedForwardTrack() {
+	return feedForwardTrack;
+    }
+
+    // Constructor for a request that does not have a feed-forward track
+    public MPFDetectionAudioRequest(int startTime,
+				    int stopTime) {
         this.startTime = startTime;
         this.stopTime = stopTime;
+	this.hasFeedForwardTrack = false;
+    }
+
+    // Constructor for a request that has a feed-forward track
+    public MPFDetectionAudioRequest(int startTime,
+				    int stopTime,
+				    MPFAudioTrack track) {
+        this.startTime = startTime;
+        this.stopTime = stopTime;
+	this.hasFeedForwardTrack = true;
+	this.feedForwardTrack = track;
     }
 
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionImageRequest.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionImageRequest.java
@@ -29,24 +29,18 @@ import org.mitre.mpf.component.api.detection.MPFImageLocation;
 
 
 public class MPFDetectionImageRequest {
-    private final boolean hasFeedForwardLocation;
     private MPFImageLocation feedForwardLocation;
 
-    public boolean hasFeedForwardLocation() {
-	return hasFeedForwardLocation;
-    }
-
     public MPFImageLocation getFeedForwardLocation() {
-	return feedForwardLocation;
+        return feedForwardLocation;   // Could be null; be sure to check
     }
 
     public MPFDetectionImageRequest() {
-	this.hasFeedForwardLocation=false;
+        this.feedForwardLocation = null;
     }
 
     public MPFDetectionImageRequest(MPFImageLocation location) {
-	this.hasFeedForwardLocation=true;
-	this.feedForwardLocation=location;
+        this.feedForwardLocation = location;
     }
 
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionImageRequest.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionImageRequest.java
@@ -25,10 +25,28 @@
  ******************************************************************************/
 
 package org.mitre.mpf.component.api.messaging.detection;
+import org.mitre.mpf.component.api.detection.MPFImageLocation;
+
 
 public class MPFDetectionImageRequest {
+    private final boolean hasFeedForwardLocation;
+    private MPFImageLocation feedForwardLocation;
 
-	public MPFDetectionImageRequest() {
+    public boolean hasFeedForwardLocation() {
+	return hasFeedForwardLocation;
+    }
+
+    public MPFImageLocation getFeedForwardLocation() {
+	return feedForwardLocation;
+    }
+
+    public MPFDetectionImageRequest() {
+	this.hasFeedForwardLocation=false;
+    }
+
+    public MPFDetectionImageRequest(MPFImageLocation location) {
+	this.hasFeedForwardLocation=true;
+	this.feedForwardLocation=location;
     }
 
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionVideoRequest.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionVideoRequest.java
@@ -25,11 +25,14 @@
  ******************************************************************************/
 
 package org.mitre.mpf.component.api.messaging.detection;
+import org.mitre.mpf.component.api.detection.MPFVideoTrack;
 
 public class MPFDetectionVideoRequest {
 
     private int startFrame;
     private int stopFrame;
+    private final boolean hasFeedForwardTrack;
+    private MPFVideoTrack feedForwardTrack;
 
     public int getStartFrame() {
         return startFrame;
@@ -47,12 +50,30 @@ public class MPFDetectionVideoRequest {
         this.stopFrame = stopFrame;
     }
 
-	public MPFDetectionVideoRequest(
-            int startFrame,
-            int stopFrame
-    ) {
+    public boolean hasFeedForwardTrack() {
+	return hasFeedForwardTrack;
+    }
+
+    public MPFVideoTrack getFeedForwardTrack() {
+	return feedForwardTrack;
+    }
+
+    // Constructor for a request that does not have a feed-forward track
+    public MPFDetectionVideoRequest(int startFrame,
+				    int stopFrame) {
         this.startFrame = startFrame;
         this.stopFrame = stopFrame;
+	this.hasFeedForwardTrack = false;
+    }
+
+    // Constructor for a request that has a feed-forward track
+    public MPFDetectionVideoRequest(int startFrame,
+				    int stopFrame,
+				    MPFVideoTrack track) {
+        this.startFrame = startFrame;
+        this.stopFrame = stopFrame;
+	this.hasFeedForwardTrack = true;
+	this.feedForwardTrack = track;
     }
 
 }

--- a/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionVideoRequest.java
+++ b/detection/java-component-api/src/main/java/org/mitre/mpf/component/api/messaging/detection/MPFDetectionVideoRequest.java
@@ -31,7 +31,6 @@ public class MPFDetectionVideoRequest {
 
     private int startFrame;
     private int stopFrame;
-    private final boolean hasFeedForwardTrack;
     private MPFVideoTrack feedForwardTrack;
 
     public int getStartFrame() {
@@ -50,30 +49,25 @@ public class MPFDetectionVideoRequest {
         this.stopFrame = stopFrame;
     }
 
-    public boolean hasFeedForwardTrack() {
-	return hasFeedForwardTrack;
-    }
-
     public MPFVideoTrack getFeedForwardTrack() {
-	return feedForwardTrack;
+        return feedForwardTrack;   // Could be null; be sure to check
     }
 
     // Constructor for a request that does not have a feed-forward track
     public MPFDetectionVideoRequest(int startFrame,
-				    int stopFrame) {
+                                    int stopFrame) {
         this.startFrame = startFrame;
         this.stopFrame = stopFrame;
-	this.hasFeedForwardTrack = false;
+        this.feedForwardTrack = null;
     }
 
     // Constructor for a request that has a feed-forward track
     public MPFDetectionVideoRequest(int startFrame,
-				    int stopFrame,
-				    MPFVideoTrack track) {
+                                    int stopFrame,
+                                    MPFVideoTrack track) {
         this.startFrame = startFrame;
         this.stopFrame = stopFrame;
-	this.hasFeedForwardTrack = true;
-	this.feedForwardTrack = track;
+        this.feedForwardTrack = track;
     }
 
 }


### PR DESCRIPTION
Added optional feed-forward locations/tracks to the Java job definitions and job requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-java-component-sdk/7)
<!-- Reviewable:end -->
